### PR TITLE
Update govuk_template.html

### DIFF
--- a/views/layouts/govuk_template.html
+++ b/views/layouts/govuk_template.html
@@ -47,7 +47,7 @@
     </div>
 
     
-    <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
+    <header role="banner" id="global-header" class="{{header_class}}">
       <div class="header-wrapper">
         <div class="header-global">
           <div class="header-logo">


### PR DESCRIPTION
For the header, the header_class will never be located due to the incorrect use of the block tag {% block header_class %}{% endblock %}. Changed to {{header_class}}. Also noticed the same thing would happen within the `<body>` declaration as body_classes will never be located either. However I haven't changed this mainly because it doesn't affect our project.